### PR TITLE
Update the version of the node docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15-slim
+FROM node:19
 
 LABEL "com.github.actions.name"="Automated value increment."
 LABEL "com.github.actions.description"="Automated value increment."


### PR DESCRIPTION
To fix #5 

The current image is `node:16.15-slim`. This includes a old version of the `git` command. This pull request updates the image version to `19` (bullseye) to solve the issue #5.